### PR TITLE
Corrige problema com tamanho do nome do pokémon

### DIFF
--- a/backend/src/middleware/validateAndTransformPokemonName.middleware.ts
+++ b/backend/src/middleware/validateAndTransformPokemonName.middleware.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { z } from "zod";
 
-const PokemonNameSchema = z.string().min(1).transform((pokemonName) => pokemonName.toLowerCase());
+const PokemonNameSchema = z.string().min(2).transform((pokemonName) => pokemonName.toLowerCase());
 
 const validateAndTransformPokemonName = (req: Request, res: Response, next: NextFunction): void => {
 
@@ -13,7 +13,7 @@ const validateAndTransformPokemonName = (req: Request, res: Response, next: Next
     next();
 
   } catch (error) {
-    res.status(400).json({ error: "Nome do Pokémon inválido" });
+    res.status(400).json({ error: "Nome do Pokémon inválido." });
   }
 };
 

--- a/frontend/src/app/components/Form/Form.tsx
+++ b/frontend/src/app/components/Form/Form.tsx
@@ -21,31 +21,32 @@ export default function Form(){
     const [isLoading, setIsLoading] = useState(false)
 
     async function handleGetPokemonData(event: React.FormEvent) {
-        setIsLoading(true)
         event.preventDefault();
-        try {
-          const response = await fetch(`http://localhost:3333/api/pokemons/${pokemonName}`);
-          if (!response.ok) {
-            const errorData = await response.json();
-            const errorMessage = errorData.error.message;
-            throw new Error(`${errorMessage}`);
-          }
-          const result = await response.json();
-          setPokemonData(result);
-          setIsLoading(false)
-        } catch (error: any) {
-            toast.error(error.message);
-            setIsLoading(false)
-        } 
+        if(pokemonName.length < 3){
+            toast.error("Nome do pokémon inválido. Digite ao menos 3 caracteres!")
+        } else{
+            setIsLoading(true)
+            try {
+              const response = await fetch(`http://localhost:3333/api/pokemons/${pokemonName}`);
+              if (!response.ok) {
+                const errorData = await response.json();
+                const errorMessage = errorData.error.message;
+                throw new Error(`${errorMessage}`);
+              }
+              const result = await response.json();
+              setPokemonData(result);
+              setIsLoading(false)
+            } catch (error: any) {
+                toast.error(error.message);
+                setIsLoading(false)
+            } 
+        }
       }
 
     function handleSetPokemonName(value: string){
-        if(value.length < 3) {
-            setPokemonData(null)
-        }else{
-            setPokemonName(value)
-        }
+        setPokemonName(value)        
     }
+
 
 return (
         <section className="flex">


### PR DESCRIPTION
Verifiquei que estava ocorrendo um problema na validação do tamanho do nome do pokémon e o erro não estava sendo retornado corretamente no `toastify`.

Adicionei uma validação antes de fazer a requisição para o backend para resolver a questão.